### PR TITLE
Don't check return value of sws_scale

### DIFF
--- a/lottie/lottie_cache.cpp
+++ b/lottie/lottie_cache.cpp
@@ -138,7 +138,7 @@ void DecodeYUV2RGB(
 	uint8_t *dst[AV_NUM_DATA_POINTERS] = { to.bits(), nullptr };
 	int dstLineSize[AV_NUM_DATA_POINTERS] = { to.bytesPerLine(), 0 };
 
-	const auto lines = sws_scale(
+	sws_scale(
 		context.get(),
 		src,
 		srcLineSize,
@@ -146,8 +146,6 @@ void DecodeYUV2RGB(
 		to.height(),
 		dst,
 		dstLineSize);
-
-	Ensures(lines == to.height());
 }
 
 void DecodeAlpha(QImage &to, const EncodedStorage &from) {
@@ -215,7 +213,7 @@ void EncodeRGB2YUV(
 		0
 	};
 
-	const auto lines = sws_scale(
+	sws_scale(
 		context.get(),
 		src,
 		srcLineSize,
@@ -223,8 +221,6 @@ void EncodeRGB2YUV(
 		from.height(),
 		dst,
 		dstLineSize);
-
-	Ensures(lines == from.height());
 }
 
 void EncodeAlpha(EncodedStorage &to, const QImage &from) {


### PR DESCRIPTION
ffmpeg has a bug in assembler code: https://gitlab.alpinelinux.org/alpine/aports/-/issues/11722